### PR TITLE
Show the permission set for enable it on repo

### DIFF
--- a/.github/workflows/auto-pr-description.yml
+++ b/.github/workflows/auto-pr-description.yml
@@ -8,9 +8,10 @@ jobs:
   generate-pr-description:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
+      repository-projects: write
 
     steps:
       - name: Check out repository

--- a/.github/workflows/auto-pr-description.yml
+++ b/.github/workflows/auto-pr-description.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Auto-generate PR Description
-        uses: hqnicolas/auto-pr-description-g4f-action@v1.2.3
+        uses: hqnicolas/auto-pr-description-g4f-action@v1.2.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           model: 'o1-mini'

--- a/.github/workflows/auto-pr-description.yml
+++ b/.github/workflows/auto-pr-description.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Auto-generate PR Description
-        uses: hqnicolas/auto-pr-description-g4f-action@v1
+        uses: hqnicolas/auto-pr-description-g4f-action@v1.2.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           model: 'o1-mini'

--- a/.github/workflows/auto-pr-description.yml
+++ b/.github/workflows/auto-pr-description.yml
@@ -1,4 +1,4 @@
-name: Auto-generate PR description [G4F]
+name: Auto generate PR Description [C4F]
 
 on:
   pull_request:

--- a/.github/workflows/auto-pr-description.yml
+++ b/.github/workflows/auto-pr-description.yml
@@ -19,6 +19,6 @@ jobs:
           fetch-depth: 0
 
       - name: Auto-generate PR Description
-        uses: yuri-val/auto-pr-description-g4f-action@v1
+        uses: hqnicolas/auto-pr-description-g4f-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -111,7 +111,7 @@ jobs:
             }
 
       - name: Create Full Version Release
-        uses: softprops/action-gh-release@v1
+        uses: hqnicolas/action-gh-release@v1
         with:
           tag_name: ${{ steps.get_tag.outputs.TAG }}
           name: Release ${{ steps.get_tag.outputs.TAG }}

--- a/.github/workflows/hq-release.yml
+++ b/.github/workflows/hq-release.yml
@@ -111,7 +111,7 @@ jobs:
             }
 
       - name: Create Full Version Release
-        uses: hqnicolas/action-gh-release@v1
+        uses: hqnicolas/action-gh-release@v2.1.0
         with:
           tag_name: ${{ steps.get_tag.outputs.TAG }}
           name: Release ${{ steps.get_tag.outputs.TAG }}

--- a/.github/workflows/hq-release.yml
+++ b/.github/workflows/hq-release.yml
@@ -1,4 +1,4 @@
-name: Auto Release
+name: HQ Release
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To set up this project locally:
 
 1. Clone the repository:
    ```
-   git clone https://github.com/yuri-val/auto-pr-description-g4f-action.git
+   git clone https://github.com/hqnicolas/auto-pr-description-g4f-action.git
    ```
 
 2. Install the required dependencies:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Auto-generate PR Description Action [G4F]
+# Auto generate PR Description Action [C4F]
 
 ![GitHub Actions](https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white)
 ![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate PR Description
-        uses: yuri-val/auto-pr-description-g4f-action@v1
+        uses:hqnicolas/auto-pr-description-g4f-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           temperature: 0.7

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Auto generate PR Description [C4F]'
 description: 'Automatically generates pull request descriptions using gpt4free when a PR is created or updated.'
-author: 'Yuri V'
+author: 'Hqnicolas'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Auto-generate PR Description [G4F]'
+name: 'Auto generate PR Description [C4F]'
 description: 'Automatically generates pull request descriptions using gpt4free when a PR is created or updated.'
 author: 'Yuri V'
 runs:


### PR DESCRIPTION
Show the permission set for enable it on repo
https://github.com/hqnicolas/Ollama-Pilot-CasaOs/actions/runs/11728270392/job/32671280967?pr=6
it's asking for permissions and it's not sharing